### PR TITLE
Fixed missing return in Ndata in COI.cpp

### DIFF
--- a/src/tasks/COI.cpp
+++ b/src/tasks/COI.cpp
@@ -336,7 +336,7 @@ CDataInfo COI::getDataInfo()
 
 unsigned int COI::GetNData()
 {
-	mLibOI->GetNData();
+	return mLibOI->GetNData();
 }
 
 int COI::GetNDataFiles()


### PR DESCRIPTION
On some environment, can lead to segfault as soon as OpenCL computation starts (since Ndata may be garbage).